### PR TITLE
fix(ci): release web-bundle needs ubuntu-latest for GLIBC 2.39

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,12 @@ jobs:
       - run: cargo test --workspace --all-targets
 
   web-bundle:
+    # ubuntu-latest (24.04), not 22.04, because the cargo-binstall-installed
+    # `dx` binary is linked against GLIBC 2.39 which only exists on 24.04+.
+    # The downstream binary builds still use 22.04 for broader compat.
     name: build web bundle (WASM)
     needs: check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Release `web-bundle` job failed on ubuntu-22.04 because the cargo-binstall-installed `dx` binary requires GLIBC 2.39 (24.04+).
- Switched to `ubuntu-latest`. The downstream binary build matrix still uses 22.04 for glibc backwards-compat.

Failing run that prompted this: https://github.com/guitaripod/unrager/actions/runs/24648713552/job/72066866019

```
dx: /lib/x86_64-linux-gnu/libc.so.6: version \`GLIBC_2.39' not found (required by dx)
```

Once merged, the `0.14.0` tag gets moved to the merge commit so the release workflow re-runs on the fix.

## Test plan
- [ ] ci.yml goes green on this PR (it bundles via the same `dx` + `ubuntu-latest` path, so any regression would surface there)
- [ ] After merge + retag: release.yml produces 12 binaries + GitHub release