### PR TITLE
fix(doctor): infer browser from UNRAGER_COOKIES_PATH instead of hardcoding Vivaldi

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@ demos/out/*.gif filter=lfs diff=lfs merge=lfs -text
 demos/out/*.mp4 filter=lfs diff=lfs merge=lfs -text
 
 install.sh linguist-detectable=false
+crates/unrager-app/assets/*.css linguist-detectable=false
+crates/unrager-app/static/*.js linguist-detectable=false
+demos/*.tape linguist-detectable=false

--- a/src/auth/chromium.rs
+++ b/src/auth/chromium.rs
@@ -238,9 +238,10 @@ pub fn probe() -> Result<Vec<ProbeResult>> {
 
 fn candidate_paths() -> Result<Vec<Candidate>> {
     if let Some(override_path) = std::env::var_os(COOKIES_PATH_ENV) {
+        let path = PathBuf::from(override_path);
         return Ok(vec![Candidate {
-            browser: &BROWSERS[0],
-            path: PathBuf::from(override_path),
+            browser: infer_browser_from_path(&path),
+            path,
         }]);
     }
 
@@ -266,6 +267,22 @@ fn candidate_paths() -> Result<Vec<Candidate>> {
         }
     }
     Ok(out)
+}
+
+/// Best-effort match of an override path against any known browser's install roots.
+/// Both linux and macos roots are scanned so the override works regardless of host OS.
+/// Falls back to the first entry only when nothing matches — the caller's display layer
+/// relies on this returning *some* browser so labels stay stable.
+fn infer_browser_from_path(path: &Path) -> &'static Browser {
+    let path_str = path.to_string_lossy();
+    for browser in BROWSERS {
+        for root in browser.linux_roots.iter().chain(browser.macos_roots.iter()) {
+            if path_str.contains(root) {
+                return browser;
+            }
+        }
+    }
+    &BROWSERS[0]
 }
 
 fn browser_roots(browser: &Browser) -> &'static [&'static str] {
@@ -425,4 +442,56 @@ fn is_printable(bytes: &[u8]) -> bool {
     bytes
         .iter()
         .all(|b| *b == b'\t' || *b == b'\n' || *b == b'\r' || (*b >= 0x20 && *b < 0x7f))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn infer_browser_labels_macos_chrome_override() {
+        let path =
+            PathBuf::from("/Users/alice/Library/Application Support/Google/Chrome/Default/Cookies");
+        assert_eq!(infer_browser_from_path(&path).label, "Chrome");
+    }
+
+    #[test]
+    fn infer_browser_labels_linux_chrome_override() {
+        let path = PathBuf::from("/home/alice/.config/google-chrome/Default/Cookies");
+        assert_eq!(infer_browser_from_path(&path).label, "Chrome");
+    }
+
+    #[test]
+    fn infer_browser_labels_brave_override() {
+        let path = PathBuf::from(
+            "/Users/alice/Library/Application Support/BraveSoftware/Brave-Browser/Default/Cookies",
+        );
+        assert_eq!(infer_browser_from_path(&path).label, "Brave");
+    }
+
+    #[test]
+    fn infer_browser_labels_edge_override() {
+        let path = PathBuf::from(
+            "/Users/alice/Library/Application Support/Microsoft Edge/Default/Cookies",
+        );
+        assert_eq!(infer_browser_from_path(&path).label, "Microsoft Edge");
+    }
+
+    #[test]
+    fn infer_browser_labels_chromium_override() {
+        let path = PathBuf::from("/home/alice/.config/chromium/Default/Cookies");
+        assert_eq!(infer_browser_from_path(&path).label, "Chromium");
+    }
+
+    #[test]
+    fn infer_browser_vivaldi_still_works() {
+        let path = PathBuf::from("/home/alice/.config/vivaldi/Default/Cookies");
+        assert_eq!(infer_browser_from_path(&path).label, "Vivaldi");
+    }
+
+    #[test]
+    fn infer_browser_falls_back_on_unknown_path() {
+        let path = PathBuf::from("/tmp/totally-random.db");
+        assert_eq!(infer_browser_from_path(&path).label, BROWSERS[0].label);
+    }
 }


### PR DESCRIPTION
Closes #3.

## The bug

`src/auth/chromium.rs::candidate_paths` hardcoded the override path to `&BROWSERS[0]`, which happens to be Vivaldi. Any cookie store pointed at via `UNRAGER_COOKIES_PATH` was therefore labeled `Vivaldi` in `unrager doctor`, regardless of what browser the path actually belonged to.

```rust
// before
if let Some(override_path) = std::env::var_os(COOKIES_PATH_ENV) {
    return Ok(vec![Candidate {
        browser: &BROWSERS[0],   // ← always Vivaldi
        path: PathBuf::from(override_path),
    }]);
}
```

## The fix

`infer_browser_from_path` scans the path string against every browser's `linux_roots` + `macos_roots` and returns the first match. macOS and Linux roots are both scanned so the override is correctly labeled no matter which host OS runs the binary.

Fallback to `&BROWSERS[0]` is preserved only for genuinely unrecognizable paths — that keeps the macOS keychain lookup contract stable (the current callers still get a valid `&'static Browser`).

## Proof

### Unit tests — seven added, all pass
```
running 7 tests
test auth::chromium::tests::infer_browser_labels_macos_chrome_override ... ok
test auth::chromium::tests::infer_browser_labels_linux_chrome_override ... ok
test auth::chromium::tests::infer_browser_labels_brave_override ... ok
test auth::chromium::tests::infer_browser_labels_edge_override ... ok
test auth::chromium::tests::infer_browser_labels_chromium_override ... ok
test auth::chromium::tests::infer_browser_vivaldi_still_works ... ok
test auth::chromium::tests::infer_browser_falls_back_on_unknown_path ... ok

test result: ok. 7 passed; 0 failed
```

Full suite: **263 passed, 0 failed**. `cargo fmt --check` and `cargo clippy -- -D warnings` both clean.

### Live reproduction — the exact path from the bug report

```console
$ UNRAGER_COOKIES_PATH="$HOME/Library/Application Support/Google/Chrome/Default/Cookies" \
    unrager doctor

✗ cookies     1 cookie store(s) found, but none are logged into x.com
              → log into x.com in any of these browsers:
                Chrome (/.../Library/Application Support/Google/Chrome/Default/Cookies)
```

Previously this line read `Vivaldi (...)`. It now reads `Chrome (...)`, matching the actual browser the path belongs to.