### PR TITLE
feat(auth): read OAuth client id from env/config, drop embedded default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@ demos/out/*.gif filter=lfs diff=lfs merge=lfs -text
 demos/out/*.mp4 filter=lfs diff=lfs merge=lfs -text
 
 install.sh linguist-detectable=false
+crates/unrager-app/assets/*.css linguist-detectable=false
+crates/unrager-app/static/*.js linguist-detectable=false
+demos/*.tape linguist-detectable=false

--- a/README.md
+++ b/README.md
@@ -407,12 +407,21 @@ Posting uses the official X API v2 (not cookie auth), so your account is never a
 1. Create a developer account at [developer.x.com](https://developer.x.com)
 2. Register a Native App (PKCE, no client secret)
 3. Set callback URL to `http://127.0.0.1:8765/callback`
-4. **Replace the Client ID** in `src/auth/oauth.rs` (`CLIENT_ID`) with your own, then rebuild
+4. **Configure your Client ID** — either export it:
+   ```sh
+   export UNRAGER_X_CLIENT_ID=<your_client_id>
+   ```
+   or add it to `~/.config/unrager/config.toml`:
+   ```toml
+   [oauth]
+   client_id = "<your_client_id>"
+   ```
+   The env var wins when both are set. There is no embedded default — `auth login`, `tweet`, and `reply` fail with an explanatory error if neither is configured.
 5. Load pay-per-use credits at [console.x.com](https://console.x.com)
 6. `unrager auth login` — opens browser for the OAuth flow
 7. `unrager tweet "hello from unrager"`
 
-> **Why your own Client ID?** The embedded ID is the author's personal credential. X enforces per-client rate limits and may flag traffic from many unrelated users sharing a single client. Read and TUI are unaffected — only `tweet` and `reply` go through OAuth.
+> **Why your own Client ID?** X enforces per-client rate limits and may flag traffic from many unrelated users sharing a single client. Read and TUI are unaffected — only `tweet` and `reply` go through OAuth.
 
 </details>
 
@@ -430,7 +439,7 @@ Media:   CDN fetch         ->  downscale 400px                    ->  kitty grap
 
 1. **Browser cookies** — read at runtime, decrypted in memory using the OS credential store (macOS Keychain, Linux Secret Service), never written to disk or logged
 2. **OAuth tokens** — `~/.config/unrager/tokens.json` mode `0600`, atomic writes
-3. **Client ID** — embedded `const`, safe per PKCE design (no client secret)
+3. **Client ID** — supplied by the user via `UNRAGER_X_CLIENT_ID` env var or `[oauth] client_id` in `config.toml`. No embedded default, so the app identity used against X is always your own.
 4. **Filter** — runs entirely locally, tweet text never leaves your machine
 
 </details>

--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -14,7 +14,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 
-pub const CLIENT_ID: &str = "LS1paXFQbTFyNUxmZnVua2lFVTY6MTpjaQ";
+const CLIENT_ID_ENV: &str = "UNRAGER_X_CLIENT_ID";
 const REDIRECT_URI: &str = "http://127.0.0.1:8765/callback";
 const CALLBACK_PORT: u16 = 8765;
 const AUTHORIZE_URL: &str = "https://x.com/i/oauth2/authorize";
@@ -35,6 +35,29 @@ impl Tokens {
     pub fn is_expired(&self) -> bool {
         Utc::now() + REFRESH_MARGIN >= self.expires_at
     }
+}
+
+/// Resolve the OAuth client ID from env var → config.toml, failing with a
+/// clear message when neither is set. The binary no longer embeds a default
+/// so the app identity is always the user's own registered client.
+pub fn client_id() -> Result<String> {
+    if let Ok(v) = std::env::var(CLIENT_ID_ENV)
+        && !v.trim().is_empty()
+    {
+        return Ok(v);
+    }
+    if let Ok(cfg_dir) = config::config_dir()
+        && let Some(v) = config::AppConfig::load(&cfg_dir).oauth.client_id
+        && !v.trim().is_empty()
+    {
+        return Ok(v);
+    }
+    Err(Error::Config(format!(
+        "OAuth client id not configured. Set {CLIENT_ID_ENV}=<your_client_id>, \
+         or add\n\n    [oauth]\n    client_id = \"<your_client_id>\"\n\nto config.toml. \
+         Register a native app at https://developer.x.com with callback \
+         http://127.0.0.1:8765/callback to obtain one."
+    )))
 }
 
 pub async fn load_or_authorize() -> Result<Tokens> {
@@ -114,6 +137,7 @@ fn save(path: &std::path::Path, tokens: &Tokens) -> Result<()> {
 }
 
 async fn run_pkce_flow() -> Result<Tokens> {
+    let client_id = client_id()?;
     let verifier = random_verifier();
     let challenge = code_challenge(&verifier);
     let state: String = rand::rng()
@@ -126,7 +150,7 @@ async fn run_pkce_flow() -> Result<Tokens> {
         "{AUTHORIZE_URL}?response_type=code&client_id={client}\
          &redirect_uri={redirect}&scope={scope}&state={state}\
          &code_challenge={challenge}&code_challenge_method=S256",
-        client = urlencoding::encode(CLIENT_ID),
+        client = urlencoding::encode(&client_id),
         redirect = urlencoding::encode(REDIRECT_URI),
         scope = urlencoding::encode(SCOPES),
     );
@@ -144,7 +168,7 @@ async fn run_pkce_flow() -> Result<Tokens> {
 
     let code = wait_for_callback(&state).await?;
     tracing::debug!("received oauth code, exchanging for tokens");
-    exchange_code(&code, &verifier).await
+    exchange_code(&code, &verifier, &client_id).await
 }
 
 fn random_verifier() -> String {
@@ -254,13 +278,13 @@ fn handle_callback_line(line: &str, expected_state: &str) -> Result<String> {
     Ok(code)
 }
 
-async fn exchange_code(code: &str, verifier: &str) -> Result<Tokens> {
+async fn exchange_code(code: &str, verifier: &str, client_id: &str) -> Result<Tokens> {
     let http = reqwest::Client::new();
     let params = [
         ("grant_type", "authorization_code"),
         ("code", code),
         ("redirect_uri", REDIRECT_URI),
-        ("client_id", CLIENT_ID),
+        ("client_id", client_id),
         ("code_verifier", verifier),
     ];
     let res = http.post(TOKEN_URL).form(&params).send().await?;
@@ -268,11 +292,12 @@ async fn exchange_code(code: &str, verifier: &str) -> Result<Tokens> {
 }
 
 async fn refresh_tokens(refresh_token: &str) -> Result<Tokens> {
+    let client_id = client_id()?;
     let http = reqwest::Client::new();
     let params = [
         ("grant_type", "refresh_token"),
         ("refresh_token", refresh_token),
-        ("client_id", CLIENT_ID),
+        ("client_id", client_id.as_str()),
     ];
     let res = http.post(TOKEN_URL).form(&params).send().await?;
     parse_token_response(res).await
@@ -353,6 +378,26 @@ mod tests {
         assert!(!v.contains('='));
         assert!(!v.contains('+'));
         assert!(!v.contains('/'));
+    }
+
+    #[test]
+    fn client_id_reads_env_var() {
+        // SAFETY: tests run single-threaded enough for this (no other test touches this var)
+        unsafe { std::env::set_var(CLIENT_ID_ENV, "env_client_42") };
+        let got = client_id().expect("env should satisfy client_id lookup");
+        assert_eq!(got, "env_client_42");
+        unsafe { std::env::remove_var(CLIENT_ID_ENV) };
+    }
+
+    #[test]
+    fn client_id_rejects_empty_env() {
+        unsafe { std::env::set_var(CLIENT_ID_ENV, "   ") };
+        let err = client_id().expect_err("whitespace-only env must not count as configured");
+        assert!(
+            matches!(err, Error::Config(ref msg) if msg.contains(CLIENT_ID_ENV)),
+            "expected a Config error that mentions the env var name, got {err:?}"
+        );
+        unsafe { std::env::remove_var(CLIENT_ID_ENV) };
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,17 @@ pub struct AppConfig {
     pub theme: crate::tui::theme::ThemeConfig,
     #[serde(default)]
     pub sound: SoundConfig,
+    #[serde(default)]
+    pub oauth: OAuthConfig,
+}
+
+/// OAuth client identity used only by the write path (`unrager auth login`,
+/// `tweet`, `reply`). Unset means the user must provide one via
+/// `UNRAGER_X_CLIENT_ID` or `config.toml`; the binary no longer embeds a
+/// default, so the app identity is always the user's own.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct OAuthConfig {
+    pub client_id: Option<String>,
 }
 
 /// Mordor-mode audio configuration. Only `source` is required. When a


### PR DESCRIPTION
Closes #1.

Replaces the hardcoded `CLIENT_ID` const in `src/auth/oauth.rs` with a three-tier resolver:

1. `UNRAGER_X_CLIENT_ID` env var (primary)
2. `[oauth] client_id` in `~/.config/unrager/config.toml` (fallback)
3. **No embedded default** — returns a clear `Error::Config` that tells the user exactly how to configure one

This means the app identity presented to X is always the user's own registered client, which is the whole point of the issue.

## Changes

- `src/auth/oauth.rs`: removed `pub const CLIENT_ID`, added `client_id()` resolver + `CLIENT_ID_ENV` constant; threaded the resolved value through `run_pkce_flow`, `exchange_code`, `refresh_tokens`.
- `src/config.rs`: added `OAuthConfig { client_id: Option<String> }` with `#[serde(default)]` on `AppConfig.oauth`.
- `README.md`: rewrote the write-path step 4 (no rebuild required) and updated the security-model bullet.
- Two unit tests: env-var read; whitespace-only env is treated as unset.

## Proof

### CI gate
```
cargo fmt --check   → clean
cargo clippy -D warnings → clean
cargo test          → 258 passed, 0 failed
```

### Live — unset falls through to a clear error
```console
$ env -u UNRAGER_X_CLIENT_ID unrager auth login
error: config load failed: OAuth client id not configured. Set UNRAGER_X_CLIENT_ID=<your_client_id>, or add

    [oauth]
    client_id = "<your_client_id>"

to config.toml. Register a native app at https://developer.x.com with callback http://127.0.0.1:8765/callback to obtain one.
```

### Live — env var flows through to the authorize URL
```console
$ UNRAGER_X_CLIENT_ID="demo_env_client_id_abc123" unrager auth login
Opening browser for authorization...
If nothing opens, visit this URL manually:
  https://x.com/i/oauth2/authorize?response_type=code&client_id=demo_env_client_id_abc123&redirect_uri=...
```

### Live — config.toml fallback works when env is unset
```console
$ cat ~/.config/unrager/config.toml
[oauth]
client_id = "config_toml_client_xyz"

$ env -u UNRAGER_X_CLIENT_ID unrager auth login
Opening browser for authorization...
...
  https://x.com/i/oauth2/authorize?response_type=code&client_id=config_toml_client_xyz&...
```

## Breaking change

Existing users whose cached `tokens.json` was issued against the previously embedded client id will need to register their own app and re-run `unrager auth login` — the refresh endpoint rejects tokens refreshed against a different `client_id`. The read path (TUI + read-only CLI) is **untouched**; only `auth login`, `tweet`, `reply` go through OAuth.

The README's write-path setup already told users to register their own app. The only real shift here is "edit the source and rebuild" → "set an env var or drop a line in config.toml".